### PR TITLE
Apply to become a kagent Reviewer - mesutoezdil

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ Please keep the table sorted.
 
 | Reviewer | GitHub ID | Specialization Areas | Company Affiliation |
 | ---- | ---- | ---- | ---- |
+| Mesut Oezdil | mesutoezdil | kagent | Adfinis |
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ Review the following resources to contribute to the kagent project.
 ## Governance
 
 For the kagent community's governance model, review the [governance doc](https://github.com/kagent-dev/community/blob/main/GOVERNANCE.md).
+
+<!-- membership request -->
+


### PR DESCRIPTION
# "**Reviewer**" Request for Kagent-dev

GitHub user ID: mesutoezdil

Company affiliation: Adfinis

Discord: matsuo777basho

Requirements:

- [x] I have reviewed the project [contributing guide](https://github.com/kagent-dev/kagent/blob/main/CONTRIBUTING.md)
- [x] I have enabled [2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa) on my GitHub account
- [x] I have joined the [kagent discord](https://discord.com/invite/Fu3k65f2k3)
- [x] I have attended a community meeting (attending every Tuesday and Thursday)
- [x] I will abide by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
- [x] I will follow the [Linux Foundation Generative AI policy](https://www.linuxfoundation.org/legal/generative-ai) when using AI assistance, and will indicate when non-trivial AI assistance was used

Provide a link to at least one PR that you have successfully pushed to one of the project's repos:

**Merged (31):**

1. [#2110](https://github.com/kagent-dev/kagent/pull/2110) docs: replace outdated AutoGen reference in SECURITY.md
2. [#2070](https://github.com/kagent-dev/kagent/pull/2070) docs: fix typos and errors in component READMEs
3. [#2069](https://github.com/kagent-dev/kagent/pull/2069) docs: fix typos and list formatting in contributor docs
4. [#2068](https://github.com/kagent-dev/kagent/pull/2068) docs: fix duplicate descriptions and broken link in README
5. [#2039](https://github.com/kagent-dev/kagent/pull/2039) fix(helm): rename $defaultProfider to $defaultProvider
6. [#2029](https://github.com/kagent-dev/kagent/pull/2029) fix: duplicate error message in responses and panic risk in OTEL env vars
7. [#2011](https://github.com/kagent-dev/kagent/pull/2011) fix(adk): write materialized secret files with 0600 permissions
8. [#1989](https://github.com/kagent-dev/kagent/pull/1989) fix(bedrock): stream events incrementally instead of buffering
9. [#1982](https://github.com/kagent-dev/kagent/pull/1982) feat(observability): add configurable grafana.prometheusDatasourceName to agent chart
10. [#1972](https://github.com/kagent-dev/kagent/pull/1972) fix(translator): apply temperature/maxTokens/topP for AzureOpenAI
11. [#1970](https://github.com/kagent-dev/kagent/pull/1970) feat(api): add workingDir to BYO agent deployment spec
12. [#1962](https://github.com/kagent-dev/kagent/pull/1962) fix(translator): forward Anthropic config fields to model config
13. [#1960](https://github.com/kagent-dev/kagent/pull/1960) fix(mcp): handle null tools field in MCP server configs
14. [#1959](https://github.com/kagent-dev/kagent/pull/1959) fix(openai): apply ReasoningEffort in applyOpenAIConfig
15. [#1873](https://github.com/kagent-dev/kagent/pull/1873) fix(bedrock): preserve thinking blocks in multi-turn tool use
16. [#1849](https://github.com/kagent-dev/kagent/pull/1849) feat(helm): expose context compaction in all agent subcharts
17. [#1848](https://github.com/kagent-dev/kagent/pull/1848) fix(controller): preserve nil replicas in BYO deployment to allow HPA management
18. [#1845](https://github.com/kagent-dev/kagent/pull/1845) feat(controller): set appProtocol on agent Service when a2aConfig is set
19. [#1773](https://github.com/kagent-dev/kagent/pull/1773) fix(httpserver): replace stdlib log with structured logr in memory handler
20. [#1772](https://github.com/kagent-dev/kagent/pull/1772) fix(controller): wrap secret fetch errors with %w to preserve error chain
21. [#1737](https://github.com/kagent-dev/kagent/pull/1737) feat(go-adk): propagate A2A message metadata as OTEL span attributes
22. [#1733](https://github.com/kagent-dev/kagent/pull/1733) fix(go-adk): forward allowedHeaders from incoming request to MCP tool calls
23. [#1732](https://github.com/kagent-dev/kagent/pull/1732) feat(bedrock): add top_k and extended thinking support for Claude models
24. [#1730](https://github.com/kagent-dev/kagent/pull/1730) fix(bedrock): sanitize tool names to satisfy Bedrock Converse API constraint
25. [#1724](https://github.com/kagent-dev/kagent/pull/1724) feat: add extraContainers to SharedDeploymentSpec for sidecar support
26. [#1719](https://github.com/kagent-dev/kagent/pull/1719) fix: replace retired claude-3-5-haiku-20241022 with claude-haiku-4-5
27. [#1716](https://github.com/kagent-dev/kagent/pull/1716) fix(cli): recognize all providers in install and improve missing key error
28. [#1715](https://github.com/kagent-dev/kagent/pull/1715) docs: update go/README.md to reflect single-module structure
29. [#1700](https://github.com/kagent-dev/kagent/pull/1700) docs(samples): correct KAgent controller port in sample READMEs
30. [#1699](https://github.com/kagent-dev/kagent/pull/1699) docs(python): correct KAgent controller port in package READMEs
31. [#1698](https://github.com/kagent-dev/kagent/pull/1698) docs: bump required Go version to 1.26.1 in DEVELOPMENT.md

**Open (under review):**

- [#2144](https://github.com/kagent-dev/kagent/pull/2144) docs: fix typos, stale content, and port inconsistencies
- [#2042](https://github.com/kagent-dev/kagent/pull/2042) fix(translator): honor APIKeyPassthrough for Gemini provider
- [#1998](https://github.com/kagent-dev/kagent/pull/1998) fix(controller): decouple skills from privileged sandbox

### Community Involvement

- Contributor and Reviewer in the [HAMi project](https://www.linkedin.com/feed/update/urn:li:activity:7452699490500792321/)
- DevOps Engineer at Adfinis, working on real-world Kubernetes and GPU workloads
- Publishing technical content on [Substack](https://mesutoezdil.substack.com/profile/posts) ("AR-Kube") and [Medium](https://medium.com/@mesutoezdil), focused on AI infrastructure and Kubernetes
- Sharing hands-on experiments (including running kagent with HAMi on real GPU infrastructure) with the CNCF community
- Attending community meetings regularly every Tuesday and Thursday
- Active in the kagent Discord channel (matsuo777basho)

### Motivation

I've been a _contributor_ since March 2026, with 31 merged PRs spanning bug fixes, features, and docs across Bedrock, go-adk, Helm, CLI, and the controller. 
Per the contributor ladder, **Reviewer** requirements are: at least one merged PR, Discord membership, 2FA, and attending at least one community meeting. I meet all of these.

The criteria around larger autonomous work and measured reviews are listed under _Maintainer_, not _Reviewer_. Happy to keep contributing at this pace either way, but based on the documented ladder, **Reviewer** is the right level.

I plan to keep contributing regularly and help bridge production use cases with the project's development.
